### PR TITLE
Bugfix: Opening other file after caching fails

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -23,12 +23,9 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ([
-/* 0 */,
+/* 0 */ null,
 /* 1 */
 /***/ ((__unused_webpack_module, exports) => {
-
-
-
       Object.defineProperty(exports, "__esModule", ({
         value: true
       }));
@@ -1824,9 +1821,9 @@
           this.pdfOutlineViewer.reset();
           this.pdfAttachmentViewer.reset();
           this.pdfLayerViewer.reset();
-          this.pdfSummaryViewer.reset();
-          this.pdfKnowledgeGraphViewer.reset();
-          this.pdfReferencesViewer, reset();
+          this.pdfSummaryViewer?.reset();
+          this.pdfKnowledgeGraphViewer?.reset();
+          this.pdfReferencesViewer?.reset();
           this.pdfHistory?.reset();
           this.findBar?.reset();
           this.toolbar.reset();
@@ -3003,12 +3000,17 @@
           const file = evt.fileInput.files[0];
           let url = URL.createObjectURL(file);
           if (file.name) {
-            url = {
-              url,
-              originalUrl: file.name
-            };
-          }
-          PDFViewerApplication.open(url);
+						const reader = new FileReader();
+						reader.readAsDataURL(file); 
+						reader.onloadend = function() {
+							localStorage.setItem("lastOpenedFile", reader.result);
+						}
+						url = {
+							url,
+							originalUrl: file.name
+						};
+					}
+					PDFViewerApplication.open(url);
         };
         var webViewerOpenFile = function (evt) {
           const fileInput = PDFViewerApplication.appConfig.openFileInput;


### PR DESCRIPTION
When @nudelkurre was during containers for the sidebar he accidentally left `this.pdfReferencesViewer, reset();` in code. A wrong syntax and the file would open because it should be `this.pdfReferencesViewer.reset();`. Small bug fix no problem 😊.