### PR TITLE
Bugfix/114 popup spawns away from cursor

### DIFF
--- a/web/modules/popupPreview.js
+++ b/web/modules/popupPreview.js
@@ -44,7 +44,6 @@
 			this.zoomInButton.style.height = `22px`;
 			this.zoomInButton.style.backgroundImage = "url(images/toolbarButton-zoomInPreview.svg)";
 			this.zoomInButton.style.backgroundPosition = "2px center";
-			this.zoomInButton.style.backgroundColor = "#FFF";
 			this.zoomBar.appendChild(this.zoomInButton);
 
 			this.zoomOutButton = document.createElement("BUTTON");
@@ -201,7 +200,6 @@
 
 		setZoom(zoomAmt) {
 			this.popupDiv.style.zoom = zoomAmt;
-			//document.getElementById(`popupDiv${this.viewerIndex}`).style.zoom = zoomAmt;
 		}
 
 		setPosition(x, y) {
@@ -298,7 +296,6 @@
 
 	let showPopupTooltipDiv = function (x, y) {
 		let p = document.getElementById("popupTooltipDiv1");
-		let eps = 3;
 		p.style.visibility = "visible";
 		p.style.left = `${x + 25}px`;
 		p.style.top = `${y - 25}px`;

--- a/web/modules/popupPreview.js
+++ b/web/modules/popupPreview.js
@@ -30,6 +30,7 @@
 			this.popupWrapper.style.border = `${POPUP_BORDER_SIZE}px solid black`; //Draw border
 			this.popupWrapper.style.backgroundColor = "#FFF";
 			this.popupWrapper.style.zIndex = `${zIndex}`;
+			this.popupWrapper.style.top = `${0}px`;
 
 			this.zoomBar = document.createElement("div");
 			this.zoomBar.setAttribute("id", `zoomBar${viewerIndex}`);
@@ -40,6 +41,7 @@
 			this.zoomBar.style.height = `46px`;
 			this.zoomBar.style.zIndex = `${zIndex}`;
 			this.zoomBar.style.visibility = "hidden";
+			this.zoomBar.style.top = `${0}px`;
 
 			this.zoomInButton = document.createElement("BUTTON");
 			this.zoomInButton.setAttribute("id", `zoomInButton${viewerIndex}`);
@@ -294,9 +296,10 @@
 		popupTooltipDiv.style.position = "absolute"; //static|absolute|fixed|relative|sticky|initial|inherit
 		popupTooltipDiv.style.backgroundColor = "#f5dd9a";
 		popupTooltipDiv.style.borderStyle = "dashed";
-		popupTooltipDiv.innerHTML = `Press "${keyUsedToPinPopup}" to pin popup window`;
+		popupTooltipDiv.innerHTML = `Press "${keyUsedToPinPopup}" to pin/unpin popup window`;
 		popupTooltipDiv.style.visibility = "hidden";
 		popupTooltipDiv.style.zIndex = "999";
+		popupTooltipDiv.style.top = `${0}px`;
 		document.body.appendChild(popupTooltipDiv);
 	};
 

--- a/web/modules/popupPreview.js
+++ b/web/modules/popupPreview.js
@@ -24,9 +24,10 @@
 
 			this.popupWrapper = document.createElement("div");
 			this.popupWrapper.setAttribute("id", `popupWrapper${viewerIndex}`);
+			this.popupWrapper.setAttribute("class", `popupWrapper${viewerIndex}`);
 			this.popupWrapper.style.position = "absolute"; //static|absolute|fixed|relative|sticky|initial|inherit
 			this.popupWrapper.style.overflow = "hidden";
-			this.popupWrapper.style.border = "1px solid black"; //Draw border
+			this.popupWrapper.style.border = `${POPUP_BORDER_SIZE}px solid black`; //Draw border
 			this.popupWrapper.style.backgroundColor = "#FFF";
 			this.popupWrapper.style.zIndex = `${zIndex}`;
 
@@ -34,9 +35,11 @@
 			this.zoomBar.setAttribute("id", `zoomBar${viewerIndex}`);
 			this.zoomBar.style.position = "absolute";
 			this.zoomBar.style.overflow = "hidden";
+			this.zoomBar.style.backgroundColor = "#BBB";
 			this.zoomBar.style.width = `22px`;
+			this.zoomBar.style.height = `46px`;
 			this.zoomBar.style.zIndex = `${zIndex}`;
-			this.zoomBar.style.display = "block";
+			//this.zoomBar.style.display = "block";
 
 			this.zoomInButton = document.createElement("BUTTON");
 			this.zoomInButton.setAttribute("id", `zoomInButton${viewerIndex}`);
@@ -81,13 +84,13 @@
 				.resizable({
 					handles: "all",
 					resize: function (event, ui) {
-						document.getElementById(`zoomBar${viewerIndex}`).style.left = `${ui.position.left - 25}px`;
+						document.getElementById(`zoomBar${viewerIndex}`).style.left = `${ui.position.left - 22}px`;
 						document.getElementById(`zoomBar${viewerIndex}`).style.top = `${ui.position.top}px`;
 					},
 				})
 				.draggable({
 					drag: function (event, ui) {
-						document.getElementById(`zoomBar${viewerIndex}`).style.left = `${ui.position.left - 25}px`;
+						document.getElementById(`zoomBar${viewerIndex}`).style.left = `${ui.position.left - 22}px`;
 						document.getElementById(`zoomBar${viewerIndex}`).style.top = `${ui.position.top}px`;
 					},
 				});
@@ -171,7 +174,7 @@
 		}
 
 		pin() {
-			this.popupWrapper.style.border = "3px solid black";
+			this.popupWrapper.style.border = `${POPUP_PINNED_BORDER_SIZE}px solid black`;
 			this.pinned = true;
 		}
 
@@ -207,7 +210,7 @@
 			this.position.y = y;
 			this.popupWrapper.style.left = `${this.position.x + this.offset.x}px`;
 			this.popupWrapper.style.top = `${this.position.y + this.offset.y}px`;
-			this.zoomBar.style.left = `${this.position.x + this.offset.x - 25}px`;
+			this.zoomBar.style.left = `${this.position.x + this.offset.x - 22}px`;
 			this.zoomBar.style.top = `${this.position.y + this.offset.y}px`;
 		}
 
@@ -216,7 +219,7 @@
 			this.offset.y = offY;
 			this.popupWrapper.style.left = `${this.position.x + this.offset.x}px`;
 			this.popupWrapper.style.top = `${this.position.y + this.offset.y}px`;
-			this.zoomBar.style.left = `${this.position.x + this.offset.x - 25}px`;
+			this.zoomBar.style.left = `${this.position.x + this.offset.x - 22}px`;
 			this.zoomBar.style.top = `${this.position.y + this.offset.y}px`;
 		}
 
@@ -267,6 +270,8 @@
 	let currentlyMouseoverdPinnedPopup = null;
 	let zIndex = 10;
 	const POPUP_INIT_SCALE = 0.7;
+	const POPUP_BORDER_SIZE = 4;
+	const POPUP_PINNED_BORDER_SIZE = 6;
 	let popupTooltipDiv;
 
 	// Initializer method
@@ -291,6 +296,7 @@
 		popupTooltipDiv.style.borderStyle = "dashed";
 		popupTooltipDiv.innerHTML = `Press "${keyUsedToPinPopup}" to pin popup window`;
 		popupTooltipDiv.style.visibility = "hidden";
+		popupTooltipDiv.style.zIndex = "999";
 		document.body.appendChild(popupTooltipDiv);
 	};
 
@@ -388,6 +394,9 @@
 
 		//Hyperlink Parent
 		const refParent = event.target.parentElement;
+		let refBoundingRect = refParent.getBoundingClientRect();
+		console.log("refParent:" + JSON.stringify(refParent.getBoundingClientRect()));
+		console.log("refParent:" + refParent.getBoundingClientRect().y);
 
 		refParent.addEventListener("mouseleave", function () {
 			hidePopupTooltipDiv();
@@ -452,12 +461,16 @@
 				let viewPort = pdfPage.getViewport({ scale: currentViewer.getCurrentScale() * POPUP_INIT_SCALE });
 				maxHeight = viewPort.height * currentViewer.getCurrentScale() < pdfPage.view[3] * 0.5 ? viewPort.height * currentViewer.getCurrentScale() : pdfPage.view[3] * 0.5;
 				currentViewer.setSize(viewPort.width * currentViewer.getCurrentScale(), maxHeight);
-				currentViewer.setPosition(event.clientX, event.clientY);
+
+				let x = refBoundingRect.x + refBoundingRect.width / 2;
+				let y = refBoundingRect.y + refBoundingRect.height / 2;
+
+				currentViewer.setPosition(x, y);
 
 				if (event.clientY > screen.height / 2) {
-					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), -(5 + maxHeight));
+					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), -(refBoundingRect.height + maxHeight + 5));
 				} else {
-					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), 8);
+					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), refBoundingRect.height);
 				}
 			}
 		});

--- a/web/modules/popupPreview.js
+++ b/web/modules/popupPreview.js
@@ -39,7 +39,7 @@
 			this.zoomBar.style.width = `22px`;
 			this.zoomBar.style.height = `46px`;
 			this.zoomBar.style.zIndex = `${zIndex}`;
-			//this.zoomBar.style.display = "block";
+			this.zoomBar.style.visibility = "hidden";
 
 			this.zoomInButton = document.createElement("BUTTON");
 			this.zoomInButton.setAttribute("id", `zoomInButton${viewerIndex}`);
@@ -395,8 +395,6 @@
 		//Hyperlink Parent
 		const refParent = event.target.parentElement;
 		let refBoundingRect = refParent.getBoundingClientRect();
-		console.log("refParent:" + JSON.stringify(refParent.getBoundingClientRect()));
-		console.log("refParent:" + refParent.getBoundingClientRect().y);
 
 		refParent.addEventListener("mouseleave", function () {
 			hidePopupTooltipDiv();
@@ -450,12 +448,16 @@
 				let viewPort = pdfPage.getViewport({ scale: POPUP_INIT_SCALE });
 				maxHeight = viewPort.height * currentViewer.getCurrentScale() < pdfPage.view[3] * 0.5 ? viewPort.height * currentViewer.getCurrentScale() : pdfPage.view[3] * 0.5;
 				currentViewer.setSize(refDestination[4] * currentViewer.getCurrentScale(), maxHeight);
-				currentViewer.setPosition(event.clientX, event.clientY);
+
+				let x = refBoundingRect.x + refBoundingRect.width / 2;
+				let y = refBoundingRect.y + refBoundingRect.height / 2;
+
+				currentViewer.setPosition(x, y);
 
 				if (event.clientY > screen.height / 2) {
-					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), -(5 + maxHeight));
+					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), -(refBoundingRect.height + maxHeight + POPUP_PINNED_BORDER_SIZE));
 				} else {
-					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), 8);
+					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), refBoundingRect.height);
 				}
 			} else {
 				let viewPort = pdfPage.getViewport({ scale: currentViewer.getCurrentScale() * POPUP_INIT_SCALE });
@@ -468,7 +470,7 @@
 				currentViewer.setPosition(x, y);
 
 				if (event.clientY > screen.height / 2) {
-					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), -(refBoundingRect.height + maxHeight + 5));
+					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), -(refBoundingRect.height + maxHeight + POPUP_PINNED_BORDER_SIZE));
 				} else {
 					currentViewer.setOffset(-((viewPort.width / 2) * currentViewer.getCurrentScale()), refBoundingRect.height);
 				}

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1053,6 +1053,7 @@
 }
 
 :root {
+    --sidebar-container-bg-color: rgb(240, 240, 240);
     --dir-factor: 1;
     --sidebar-width: 255px;
     --sidebar-transition-duration: 200ms;
@@ -1156,6 +1157,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --sidebar-container-bg-color: rgb(40, 40, 40);
     --main-color: rgba(249, 249, 250, 1);
     --body-bg-color: rgba(42, 42, 46, 1);
     --progressBar-color: rgba(0, 96, 223, 1);
@@ -1337,6 +1339,7 @@ body {
   transition-property: inset-inline-start;
   transition-duration: var(--sidebar-transition-duration);
   transition-timing-function: var(--sidebar-transition-timing-function);
+  background-color: var(--sidebar-container-bg-color);
 }
 
 #outerContainer.sidebarMoving #sidebarContainer,

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -37,6 +37,8 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     <!-- External scripts -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/themes/smoothness/jquery-ui.css">
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://d3js.org/d3.v4.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>


### PR DESCRIPTION
- Reworked movement to now use JQuery, looks a lot cleaner and handles better.
- Reworked "spawn position" math of the popup, hopefully it now works universally.
- Resize functionality added.
- Content scaling/zooming implemented.
- Made sidebar container opaque to no longer cause popups to be visible behind it.
- Set a default background color for popups to remove visible gaps between pages causing the document behind to bleed through.
- Default popup window size reduced to 70%..
- Added tooltip when mouseovering a reference on how to pin the popup.