### PR TITLE
popup windows out of bounds bug fix

### DIFF
--- a/web/modules/popupPreview.js
+++ b/web/modules/popupPreview.js
@@ -75,11 +75,11 @@
 			this.popupViewerDiv.setAttribute("id", `popupViewer${viewerIndex}`);
 			this.popupViewerDiv.setAttribute("class", "pdfViewer");
 
-			document.body.appendChild(this.popupWrapper);
+			document.getElementById("popupEcosystem").appendChild(this.popupWrapper);
 			this.popupWrapper.appendChild(this.popupDiv);
 			this.popupDiv.appendChild(this.popupContainerDiv);
 			this.popupContainerDiv.appendChild(this.popupViewerDiv);
-			document.body.appendChild(this.zoomBar);
+			document.getElementById("popupEcosystem").appendChild(this.zoomBar);
 
 			//JQuery resize & drag functions
 			$(`#popupWrapper${this.viewerIndex}`)
@@ -270,7 +270,7 @@
 	let currentViewerIndex = 1;
 	let currentViewer = null;
 	let currentlyMouseoverdPinnedPopup = null;
-	let zIndex = 10;
+	let zIndex = 11;
 	const POPUP_INIT_SCALE = 0.7;
 	const POPUP_BORDER_SIZE = 4;
 	const POPUP_PINNED_BORDER_SIZE = 6;

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -52,8 +52,9 @@ See https://github.com/adobe-type-tools/cmap-resources
 </head>
 
 <body tabindex="1">
-    <div id="outerContainer">
+    <div id="popupEcosystem" style="width: 100%; height: 100%; overflow: clip; position: absolute;"></div>
 
+    <div id="outerContainer">
         <div id="sidebarContainer">
             <div id="toolbarSidebar">
                 <div id="toolbarSidebarLeft">
@@ -398,7 +399,8 @@ See https://github.com/adobe-type-tools/cmap-resources
             </div>
 
             <div id="viewerContainer" tabindex="0">
-                <div id="viewer" class="pdfViewer"></div>
+                <div id="viewer" class="pdfViewer">
+                </div>
             </div>
         </div> <!-- mainContainer -->
 
@@ -497,12 +499,6 @@ See https://github.com/adobe-type-tools/cmap-resources
     <div id="printContainer"></div>
 
     <input type="file" id="fileInput" class="hidden" accept="application/pdf">
-
-    <!-- Clippy Popup container -->
-    <div id="popupDiv" style="position:fixed;overflow:hidden;border:1px solid black">
-        <div id="popupContainer" style="position: absolute">
-            <div id="popupViewer" class="pdfViewer"></div>
-        </div>
-    </div>
+    
 </body>
 </html>


### PR DESCRIPTION
Popups now have a dedicated area div with 100% width and 100% height of the viewer window that clips anything that goes out of bounds. Any weirdness or spontaneous scrollbars should now be impossible.